### PR TITLE
[bugfix] Links missing script and adds docs

### DIFF
--- a/packages/browsalyzer/README.md
+++ b/packages/browsalyzer/README.md
@@ -60,3 +60,39 @@ endTrace();
 ```
 
 In the example above we would mark right after we render the app and then call an `endTrace` function that ensures that we schedule a micro-task after paint that transitions to a blank page. Internally browsalyzer will see this as the cue to start a new sample.
+
+## Using Bin Scripts
+
+### Prerequisites
+
+These instructions assume Mac and using homebrew.
+
+Install R
+```sh
+brew tap homebrew/science
+brew install r
+```
+
+Run R
+```sh
+R
+```
+
+Then install R packages:
+```R
+install.packages("jsonlite")
+install.packages("R6")
+install.packages("ggplot2")
+install.packages("tidyr")
+install.packages("forcats")
+install.packages("dplyr")
+q()
+```
+
+Now you can use the linked commands to plot stats:
+
+```sh
+plot
+report
+runtime-stats
+```

--- a/packages/browsalyzer/package.json
+++ b/packages/browsalyzer/package.json
@@ -24,7 +24,8 @@
   "bin": {
     "plot": "./bin/plot.R",
     "report": "./bin/report.R",
-    "runtime-stats": "./bin/runtime-stats.R"
+    "runtime-stats": "./bin/runtime-stats.R",
+    "ResultSets": "./bin/ResultSets.R"
   },
   "scripts": {
     "build": "tsc -b",


### PR DESCRIPTION
Unsure if this is necessary, but when I installed the package globally, the bin script that wasn't linked wasn't being found. It's not ideal that it gets put in the path, but I couldn't think of another way to make it available.

Added some quick docs for setting up R correctly as well.